### PR TITLE
Clone the cluster-api by HTTPs instead of SSH

### DIFF
--- a/capi-tilt/README.md
+++ b/capi-tilt/README.md
@@ -12,7 +12,7 @@ The purpose of this document is to give easy step-by-step instructions how to se
 
 ## Cloning Git Repo
 ```
-git clone git@github.com:kubernetes-sigs/cluster-api.git
+git clone https://github.com/kubernetes-sigs/cluster-api.git
 ```
 ## Install Kind
 Kind is a tool for running local Kubernetes clusters using Docker container "nodes". Run following commands to install Kind:


### PR DESCRIPTION
Since Cluster-API is an open source project, anyone can clone it. Even it is fine to use SSH to clone the repo, using HTTPS allows cloning without ssh keypair, making it easier in some cases, e.g., Cloning the repo from a VM.