### PR TITLE
Update the instructions

### DIFF
--- a/capi-tilt/README.md
+++ b/capi-tilt/README.md
@@ -3,7 +3,7 @@
 The purpose of this document is to give easy step-by-step instructions how to set up Kind cluster and use Tilt for Cluster API development and testing. For the reminder of this document, we use Kind as management cluster and Cluster API Provider Docker (CAPD) as infrastructure provider.  
 
 ## Prerequisites
-1. Go version 1.13.0+ 
+1. Go version 1.13.0+
 2. Docker
 3. Kind v0.6 or v0.7 (other clusters can be used if preload_images_for_kind is set to false)
 4. Kustomize standalone (kubectl kustomize does not work because it is missing some features of kustomize v3)
@@ -24,7 +24,7 @@ GO111MODULE="on" go get sigs.k8s.io/kind@v0.7.0
 **Note:** In Kind v0.8.0 the default docker network for nodes is different from older versions. This has cause problems, so always use version v0.7.0.
 
 ## Install tilt
-Tilt is a handy tool for local kubernetes development. The good thing about tilt is that it watches files for edits and automatically builds the container images, and applies any changes to bring the environment up-to-date in real-time. [Tilt](https://docs.tilt.dev/install.html) can be installed using the following command: 
+Tilt is a handy tool for local kubernetes development. The good thing about tilt is that it watches files for edits and automatically builds the container images, and applies any changes to bring the environment up-to-date in real-time. [Tilt](https://docs.tilt.dev/install.html) can be installed using the following command:
 
 ```
 curl -fsSL https://raw.githubusercontent.com/windmilleng/tilt/master/scripts/install.sh | bash
@@ -33,20 +33,20 @@ You should verify if the installation is correct:
 ```
 tilt version
 ```
-**Note:** 
-1. Tilt requires **Docker** to be installed as a non-root user and **kubectl** binary. It is assumed that this is already taken care of in your local environment. 
+**Note:**
+1. Tilt requires **Docker** to be installed as a non-root user and **kubectl** binary. It is assumed that this is already taken care of in your local environment.
 2. Tilt also requires a working kubernetes cluster to work on. For this purpose we are using **Kind**.
 
 ## Kind cluster
 
 Because the Docker provider needs to access Docker on the host, a custom kind cluster configuration is required. Create new **Kind** cluster with **kind-cluster-with-extramounts.yaml**:
 
-``` 
+```
 kind create cluster --config ./kind-cluster-with-extramounts.yaml
-``` 
+```
 
 ## Tiltfile
-The cluster api repository has a ```Tiltfile``` in the root directory. This ```Tiltfile``` contains all needed to tilt up the environment. 
+The cluster api repository has a ```Tiltfile``` in the root directory. This ```Tiltfile``` contains all needed to tilt up the environment.
 
 ## Create tilt-settings.json
 
@@ -63,9 +63,9 @@ Create a tilt-settings.json file and place it in your local copy of cluster-api.
 
 Run the tilt environment from your local copy of cluster api repo using the following command:
 
-``` 
-tilt up 
-``` 
+```
+tilt up
+```
 
 This will open the command-line HUD as well as a web browser interface. You can monitor Tilt’s status in either location. After a brief amount of time, you should have a running development environment, and you should now be able to create a cluster.
 
@@ -100,7 +100,7 @@ When provisioning is done. You should see:
 
 ```
 NAME              READY   INITIALIZED   REPLICAS   READY REPLICAS   UPDATED REPLICAS   UNAVAILABLE REPLICAS
-my-controlplane           true          3          3                3 
+my-controlplane           true          3                           3                  3
 ```
 
 ## Copy working cluster Kubeconfig
@@ -111,7 +111,7 @@ After the control plane node is up, you have to retrieve and save the working cl
 kubectl --namespace=default get secret/my-cluster-kubeconfig -o json | jq -r .data.value | base64 --decode > ./capi-kubeconfig
 ```
 
-## Install and patch Calico 
+## Install and patch Calico
 
 In this example we deploy Calico CNI solution. Deploy Calico using **capi-kubeconfig** copied in last step with:
 
@@ -119,7 +119,7 @@ In this example we deploy Calico CNI solution. Deploy Calico using **capi-kubeco
 kubectl --kubeconfig=capi-kubeconfig apply -f https://docs.projectcalico.org/v3.12/manifests/calico.yaml
 
 ```
-After installation you need to patch Calico deployment to avoid issues with Docker provider. 
+After installation you need to patch Calico deployment to avoid issues with Docker provider.
 
 ```
 kubectl --kubeconfig=./capi-kubeconfig \
@@ -135,6 +135,13 @@ spec:
           value: "true"
 '
 
+```
+
+When Calico is patched KCP should get into ready state. 
+
+```
+NAME              READY   INITIALIZED   REPLICAS   READY REPLICAS   UPDATED REPLICAS   UNAVAILABLE REPLICAS
+my-controlplane   true        true          3          3                3
 ```
 
 ## Create machinedeployment
@@ -159,6 +166,3 @@ worker   Running   3          3           3
 ## Docker cluster
 
 Now you have created test cluster. If you are interested to see containers running your cluster run ```docker ps```.
-
- 
-

--- a/capi-tilt/controlplane.yaml
+++ b/capi-tilt/controlplane.yaml
@@ -5,12 +5,7 @@ metadata:
   namespace: default
 spec:
   replicas: 3
-  #strategy:
-  #  type: RollingUpdate
-  #  rollingUpdate:
-  #    maxSurge: 1
-  #    maxUnavailable: 25%
-  version: v1.15.3
+  version: v1.18.0
   infrastructureTemplate:
     kind: DockerMachineTemplate
     apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
@@ -39,4 +34,3 @@ spec:
   spec:
     template:
       spec: {}
-  

--- a/capi-tilt/machine-deployment.yaml
+++ b/capi-tilt/machine-deployment.yaml
@@ -27,7 +27,7 @@ spec:
         nodepool: nodepool-0
     spec:
       clusterName: my-cluster
-      version: v1.15.3
+      version: v1.18.0
       bootstrap:
         configRef:
           name: worker


### PR DESCRIPTION
Some instructions were misleading and this PR corrects them to mitigate the confusion during testing. Controlplane.yaml and machine-deployment.yaml updated to use Kubernetes v1.18.0 